### PR TITLE
feat: initial support for dns resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,18 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "dns-lookup"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0fa3cd8dc96ada974e126a940d37d4079bbbe6a24aca15b1113c2f362441c5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys",
+]
 
 [[package]]
 name = "errno"
@@ -174,6 +192,7 @@ name = "nexuslab_port_sniffer"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dns-lookup",
 ]
 
 [[package]]
@@ -210,6 +229,16 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ repository = "https://github.com/nexus-lab-org/port-sniffer"
 
 [dependencies]
 clap = { version = "4.3.22", features = ["derive"] }
+dns-lookup = "2.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,93 @@
+use clap::Parser;
+use dns_lookup::lookup_host;
+use std::io::{self, Write};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
-use std::io::{self, Write};
-use clap::Parser;
 use std::time::Duration;
 
 const MAX_PORT: u32 = 65535;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(short='i', long="ip")]
-    ip: IpAddr,
-    #[arg(short='t', long="threads", default_value_t = 10)]
+    /// IP address
+    #[clap(short='i', long="ip")]
+    ip: Option<IpAddr>,
+
+    /// Number of threads
+    #[clap(short='t', long="threads", default_value = "10")]
     threads: u32,
+
+    /// Domain name
+    #[clap(long)]
+    domain: Option<String>,
+
 }
 
 fn main() {
     let cli = Cli::parse();
-    println!("Scanning {} with {:?} threads", cli.ip, cli.threads);
+
+    let ip_addr = match (&cli.ip, &cli.domain) {
+        (Some(ip), _) => Some(*ip),
+        (_, Some(domain)) => {
+            match hostname_to_ip(domain) {
+                Ok(ips) => {
+                    let mut resolved_ip_addr: Option<IpAddr> = None;
+                    for ip in ips {
+                        if let IpAddr::V4(_ipv4) = ip {
+                            // here ipv4 is of type IpV4Addr
+                            resolved_ip_addr = Some(ip);
+                            break;
+                        }
+                    }
+                    resolved_ip_addr
+                }
+
+                Err(e) => {
+                    eprintln!("Error getting the IP: {}", e);
+                    None
+                }
+            }
+        }
+        _ => {
+            eprintln!("Either 'ip' or 'domain' must be provided.");
+            return; // Print error and return from the function
+        }
+    };
+
+    let ip_addr = match ip_addr {
+        Some(ip) => ip,
+        None => {
+            return; // Exit
+        }
+    };
+
+    println!(
+        "Scanning {} with {:?} threads",
+        ip_addr,
+        cli.threads
+    );
     let (tx, rx) = channel::<u32>();
 
     for i in 0..cli.threads {
         let tx = tx.clone();
         thread::spawn(move || {
-            scan(tx, i, cli.ip, cli.threads);
+            scan(tx, i, ip_addr, cli.threads);
         });
     }
     drop(tx);
     let mut open: Vec<u32> = rx.iter().collect();
 
-    println!("");
+    println!();
     open.sort();
     for port in open {
         println!("{} is open", port);
     }
+}
+
+fn hostname_to_ip(hostname: &str) -> Result<Vec<IpAddr>, std::io::Error> {
+    lookup_host(hostname)
 }
 
 fn scan(tx: Sender<u32>, start_port: u32, addr: IpAddr, threads: u32) {


### PR DESCRIPTION
Added initial support for DNS based lookup, based on IPv4 address of the host url.
I have also made some structural changes as per the design recommendations by clippy.
Solves #1 

### External Crates Used
- [x] dns-lookup

### Checks
- [x] cargo check
- [x] cargo clippy
- [x] `cargo run -- --domain google.com --threads 100`
- [x] `cargo run -- -i 127.0.0.1 --threads 100`   