### PR TITLE
Add support for scanning specific ports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ use dns_lookup::lookup_host;
 use std::io::{self, Write};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc::{channel, Sender};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+const MIN_PORT: u32 = 0;
 const MAX_PORT: u32 = 65535;
 const DEFAULT_TIMEOUT: u32 = 2;
 
@@ -24,9 +26,15 @@ struct Cli {
     #[clap(long)]
     domain: Option<String>,
 
-    // Expected Timeout over each TCP connect
+    /// Expected Timeout over each TCP connect
     #[clap(long, default_value = "10")]
     timeout: u64,
+
+    /// Ports to be scanned (optional,
+    /// if unspecified, all ports will be
+    /// scanned)
+    #[clap(long, num_args=1..)]
+    ports: Option<Vec<u32>>,
 }
 
 fn main() {
@@ -55,7 +63,7 @@ fn main() {
             }
         }
         _ => {
-            eprintln!("Either 'ip' or 'domain' must be provided.");
+            eprintln!("Either 'ip' or 'domain' must be provided");
             return; // Print error and return from the function
         }
     };
@@ -67,13 +75,41 @@ fn main() {
         }
     };
 
+    // The ports to scan
+    let ports_to_scan: Arc<Vec<u32>> = match &cli.ports {
+        Some(ports) => {
+            // Some ports have been specified
+            // on the command line
+            let mut valid_ports: Vec<u32> = Vec::new();
+            for port in ports {
+                if *port < MIN_PORT || *port > MAX_PORT {
+                    // Invalid port number
+                    eprintln!(
+                        "Invalid port number specified. Port numbers should be in the range: {}-{}",
+                        MIN_PORT, MAX_PORT
+                    );
+                    return;
+                } else {
+                    valid_ports.push(*port);
+                }
+            }
+            Arc::new(valid_ports)
+        }
+        None => {
+            // No ports specified, scan all
+            Arc::new((MIN_PORT..MAX_PORT + 1).collect())
+        }
+    };
+
     println!("Scanning {} with {:?} threads", ip_addr, cli.threads);
+
     let (tx, rx) = channel::<u32>();
 
     for i in 0..cli.threads {
         let tx = tx.clone();
+        let ports_to_scan = ports_to_scan.clone();
         thread::spawn(move || {
-            scan(tx, i, ip_addr, cli.threads, cli.timeout);
+            scan(tx, ports_to_scan, i, ip_addr, cli.threads, cli.timeout);
         });
     }
     drop(tx);
@@ -81,8 +117,13 @@ fn main() {
 
     println!();
     open.sort();
-    for port in open {
-        println!("{} is open", port);
+
+    if open.is_empty() {
+        println!("None of the analysed ports were open");
+    } else {
+        for port in open {
+            println!("{} is open", port);
+        }
     }
 }
 
@@ -90,10 +131,27 @@ fn hostname_to_ip(hostname: &str) -> Result<Vec<IpAddr>, std::io::Error> {
     lookup_host(hostname)
 }
 
-fn scan(tx: Sender<u32>, start_port: u32, addr: IpAddr, threads: u32, timeout: u64) {
-    let mut port: u32 = start_port + 1;
+fn scan(
+    tx: Sender<u32>,
+    ports_to_scan: Arc<Vec<u32>>,
+    start_port_index: u32,
+    addr: IpAddr,
+    threads: u32,
+    timeout: u64,
+) {
+    // This function scans ports at positions
+    // start_port_index,
+    // start_port_index + threads,
+    // start_port_index + 2 * threads ..
+    // in ports_to_scan
+
     let duration = Duration::new(timeout, 0);
+    let mut port_index = start_port_index;
     loop {
+        if port_index >= ports_to_scan.len() as u32 {
+            break;
+        }
+        let port = ports_to_scan[port_index as usize];
         let address = format!("{}:{}", addr, port);
         let socket_add = address.to_socket_addrs().unwrap().next().unwrap();
         if TcpStream::connect_timeout(&socket_add, duration).is_ok() {
@@ -101,10 +159,6 @@ fn scan(tx: Sender<u32>, start_port: u32, addr: IpAddr, threads: u32, timeout: u
             io::stdout().flush().unwrap();
             tx.send(port).unwrap();
         }
-
-        if (MAX_PORT - port) <= threads {
-            break;
-        }
-        port += threads;
+        port_index += threads;
     }
 }


### PR DESCRIPTION
Modified main.rs:

1. Addresses issue #9 
2. Allows a `--ports` command line argument where 1 or more ports to be scanned can be specified
3. If the argument is missing all ports are scanned
