### PR TITLE
Some suggested improvements to ip/domain and port arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod constants;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,13 @@
-mod constants;
 
 use clap::Parser;
 use nexuslab_port_sniffer::models::IpOrDomain;
+use nexuslab_port_sniffer::constants::{DEFAULT_THREADS, DEFAULT_TIMEOUT, MAX_PORT, MIN_PORT};
 use std::io::{self, Write};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use constants::{DEFAULT_THREADS, DEFAULT_TIMEOUT, MIN_PORT, MAX_PORT};
-
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod constants;
 
 use clap::Parser;
-use dns_lookup::lookup_host;
+use nexuslab_port_sniffer::models::IpOrDomain;
 use std::io::{self, Write};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc::{channel, Sender};
@@ -14,17 +14,13 @@ use constants::{DEFAULT_THREADS, DEFAULT_TIMEOUT, MIN_PORT, MAX_PORT};
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    /// IP address
-    #[clap(short = 'i', long = "ip")]
-    ip: Option<IpAddr>,
+    /// IP address or domain name. Domain name will be looked up and resolved to ip
+    #[clap(index = 1)]
+    ip_or_domain: IpOrDomain,
 
     /// Number of threads
     #[clap(short = 't', long = "threads", default_value_t = DEFAULT_THREADS)]
     threads: u32,
-
-    /// Domain name
-    #[clap(long)]
-    domain: Option<String>,
 
     /// Expected Timeout over each TCP connect
     #[clap(long, default_value_t = DEFAULT_TIMEOUT)]
@@ -40,38 +36,11 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
 
-    let ip_addr = match (&cli.ip, &cli.domain) {
-        (Some(ip), _) => Some(*ip),
-        (_, Some(domain)) => {
-            match hostname_to_ip(domain) {
-                Ok(ips) => {
-                    let mut resolved_ip_addr: Option<IpAddr> = None;
-                    for ip in ips {
-                        if let IpAddr::V4(_ipv4) = ip {
-                            // here ipv4 is of type IpV4Addr
-                            resolved_ip_addr = Some(ip);
-                            break;
-                        }
-                    }
-                    resolved_ip_addr
-                }
-
-                Err(e) => {
-                    eprintln!("Error getting the IP: {}", e);
-                    None
-                }
-            }
-        }
-        _ => {
-            eprintln!("Either 'ip' or 'domain' must be provided");
-            return; // Print error and return from the function
-        }
-    };
-
-    let ip_addr = match ip_addr {
-        Some(ip) => ip,
+    let ip_addr = match cli.ip_or_domain.resolve_to_ip() {
+        Some(ip_addr) => ip_addr,
         None => {
-            return; // Exit
+            eprintln!("Invalid domain or ip provided, please provide a valid one");
+            return;
         }
     };
 
@@ -125,10 +94,6 @@ fn main() {
             println!("{} is open", port);
         }
     }
-}
-
-fn hostname_to_ip(hostname: &str) -> Result<Vec<IpAddr>, std::io::Error> {
-    lookup_host(hostname)
 }
 
 fn scan(

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,15 +82,15 @@ fn main() {
             // on the command line
             let mut valid_ports: Vec<u32> = Vec::new();
             for port in ports {
-                if *port < MIN_PORT || *port > MAX_PORT {
+                if (MIN_PORT..MAX_PORT).contains(port) {
+                    valid_ports.push(*port);
+                } else {
                     // Invalid port number
                     eprintln!(
                         "Invalid port number specified. Port numbers should be in the range: {}-{}",
                         MIN_PORT, MAX_PORT
                     );
                     return;
-                } else {
-                    valid_ports.push(*port);
                 }
             }
             Arc::new(valid_ports)

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use super::constants::{MAX_PORT, MIN_PORT};
 use std::net::IpAddr;
 use std::str::FromStr;
 
@@ -49,6 +50,53 @@ impl FromStr for IpOrDomain {
         } else {
             // Otherwise, treat it as a domain that will then be looked up
             Ok(IpOrDomain::Domain(s.to_string()))
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Ports(pub Vec<u32>);
+
+impl FromStr for Ports {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Allow port range format of x-yyyyy
+        if s.contains('-') {
+            let parts: Vec<&str> = s.split('-').collect();
+            if parts.len() != 2 {
+                return Err(String::from(
+                    "Invalid range format. Expected format: start-end",
+                ));
+            }
+
+            let start = parts[0].parse::<u32>().map_err(|e| e.to_string())?;
+            let end = parts[1].parse::<u32>().map_err(|e| e.to_string())?;
+
+            if start >= end {
+                return Err(String::from("Invalid range: start must be less than end"));
+            }
+
+            Ok(Ports((start..end).collect()))
+        } else {
+            let list: Result<Vec<u32>, _> = s
+                .split_whitespace()
+                .map(|p| p.parse::<u32>().map_err(|e| e.to_string()))
+                .collect();
+
+            match list {
+                Ok(ports) => {
+                    for port in ports.clone() {
+                        if !(MIN_PORT..MAX_PORT).contains(&port) {
+                            return Err(format!(
+                        "Invalid port number specified. Port numbers should be in the range: {}-{}",
+                        MIN_PORT, MAX_PORT));
+                        }
+                    }
+                    Ok(Ports(ports))
+                }
+                Err(e) => Err(e),
+            }
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -73,6 +73,13 @@ impl FromStr for Ports {
             let start = parts[0].parse::<u32>().map_err(|e| e.to_string())?;
             let end = parts[1].parse::<u32>().map_err(|e| e.to_string())?;
 
+            if end > MAX_PORT {
+                return Err(format!(
+                    "Invalid port rage: start and end must be within the limits of {}-{}",
+                    MIN_PORT, MAX_PORT
+                ));
+            }
+
             if start >= end {
                 return Err(String::from("Invalid range: start must be less than end"));
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,54 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use dns_lookup::lookup_host;
+
+#[derive(Clone, Debug)]
+pub enum IpOrDomain {
+    Ip(IpAddr),
+    Domain(String),
+}
+
+impl IpOrDomain {
+    pub fn resolve_to_ip(&self) -> Option<IpAddr> {
+        match self {
+            IpOrDomain::Ip(ip) => Some(*ip),
+            IpOrDomain::Domain(domain) => {
+                // Resolve domain name to IP address
+                match lookup_host(domain) {
+                    Ok(ips) => {
+                        let mut resolved_ip_addr: Option<IpAddr> = None;
+                        for ip in ips {
+                            if let IpAddr::V4(_ipv4) = ip {
+                                // here ipv4 is of type IpV4Addr
+                                resolved_ip_addr = Some(ip);
+                                break;
+                            }
+                        }
+                        resolved_ip_addr
+                    }
+
+                    Err(e) => {
+                        eprintln!("Error getting the IP: {}", e);
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Clap uses FromStr to attempt to parse the text provided as args to the cmd
+impl FromStr for IpOrDomain {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Check if it's a valid ip address
+        if let Ok(ip) = s.parse() {
+            Ok(IpOrDomain::Ip(ip))
+        } else {
+            // Otherwise, treat it as a domain that will then be looked up
+            Ok(IpOrDomain::Domain(s.to_string()))
+        }
+    }
+}


### PR DESCRIPTION
Hiya! 

There aren't any contributions guidelines thus far, but in the spirit of Hacktoberfest and wanting to improve my capabilities in the Rust and Clap, I decided to try to improve the arguments passed to the program through clap. 

The changes are mainly:

## Extend port argument to allow for ranges as well

I first decided to tackle the Readme issue, but while trying out the tool (which was blazingly fast btw!), I couldn't figure out how to scan a given address for a range of ports, without having to supply the ports as a long list separated by spaces, like so:

```bash
port-sniffer -i 127.0.0.1 -p 10 11 12 13 14 15 16 17 18 19 20 ...... 3000 3001 3002 3003
```

Maybe there's an easy way with the correct knowledge in bash, but I wanted to try to implement something that would allow for the following argument:

```bash
port-sniffer -i 127.0.0.1 -p 10-3003
```

While ensuring that the following syntax still works:

```bash
port-sniffer -i 127.0.0.1 -p 80 443 22 8080
```

And that's mainly what happens in the commit [extend port argument to be either a list of numbers, or a range from x-y](https://github.com/nexus-lab-org/port-sniffer/commit/03db0edd85fa0841c9d7c30034d487c8e88dc1e3)

> *Note on possible future improvement:
> Maybe `port-sniffer 127.0.0.1 -p 40 80 101-901 1040-2000` might be a fun use-case, which should be possible if the FromStr implementation for Ports is extended to handle it? 😄 

## Combine IP address and Domain into one positioned argument

After trying out with providing both -i and --domain flags, it seems like the cmd will always prefer the ip address, so I figured that there wouldn't be an intended case where both are provided at the same time, meaning that it might make sense to merge them?

So that's what I did, and at the same time I tried out positional arguments, meaning that instead of providing -i or -d flag, it could make sense to just have that be the first argument always?

Meaning, from this:

```bash
port-sniffer -i 127.0.0.1
// or
port-sniffer --domain google.com
```

to this:

```bash
port-sniffer 127.0.0.1
// or
port-sniffer google.com
```

And then provide the flags afterwards, like so:

```bash
port-sniffer 127.0.0.1 -p 40-5000 -t 8
```

This one might be more of a subjective preference and how I expected the tool to work, and it sort of forces the user to provide the ip/domain as the first argument before adding more flags. So unlike the port changes, where I see it as a clear improvement, I can exclude the changes to ip/domain if it doesn't match the direction you want the project to go. 😺 

This change is contained in the commit [merge ip address and domain args into 1 positioned arg](https://github.com/nexus-lab-org/port-sniffer/commit/05933343ee07dce938f0c096bdeeb28f56243cda).

