### PR TITLE
fix: port range inclusive + test case added

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn scan(
     ports_to_scan: Arc<Vec<u32>>,
     start_port_index: u32,
     addr: IpAddr,
-    threads: u32,
+    total_threads: u32,
     timeout: u64,
 ) {
     // This function scans ports at positions
@@ -100,6 +100,6 @@ fn scan(
             io::stdout().flush().unwrap();
             tx.send(port).unwrap();
         }
-        port_index += threads;
+        port_index += total_threads;
     }
 }


### PR DESCRIPTION
* Added test cases for impl functions
* Fix port range issue - #20 

### Checks
- [x] cargo check
- [x] cargo clippy
- [x] `cargo run -- google.com --threads 100`
- [x] `cargo run -- 127.0.0.1 --threads 100`   