### PR TITLE
feat(ui): enhanced sigint handling and progress display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -129,13 +129,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -147,8 +171,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "socket2",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -165,23 +195,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -201,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "humantime"
@@ -212,27 +231,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -251,9 +298,11 @@ name = "nexuslab_port_sniffer"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "colored",
  "ctrlc",
  "dns-lookup",
  "env_logger",
+ "indicatif",
  "log",
 ]
 
@@ -267,6 +316,18 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "proc-macro2"
@@ -317,15 +378,15 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -335,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -369,6 +430,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "utf8parse"
@@ -409,11 +476,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -422,14 +513,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -439,9 +536,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -451,9 +560,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -463,9 +584,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,29 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -43,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -58,15 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "cc"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,20 +64,19 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.22"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b417ae4361bca3f5de378294fc7472d3c4ed86a5ef9f49e93ae722f432aae8d2"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.22"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c90dc0f0e42c64bff177ca9d7be6fcc9ddb0f26a6e062174a61c84dd6c644d4"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -97,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -109,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -142,60 +131,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "nexuslab_port_sniffer"
@@ -218,16 +163,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -239,19 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -272,9 +198,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -283,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "utf8parse"
@@ -304,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -319,42 +245,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.3"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
+dependencies = [
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "dns-lookup"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +202,19 @@ name = "nexuslab_port_sniffer"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "dns-lookup",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/nexus-lab-org/port-sniffer"
 [dependencies]
 clap = { version = "4.3.22", features = ["derive"] }
 dns-lookup = "2.0.3"
-ctrlc = "3.4.1"
 log = "0.4.14"
 env_logger = "0.9.0"
+indicatif = "0.17.7"
+ctrlc = "3.4.1"
+colored = "2.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ repository = "https://github.com/nexus-lab-org/port-sniffer"
 [dependencies]
 clap = { version = "4.3.22", features = ["derive"] }
 dns-lookup = "2.0.3"
+ctrlc = "3.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@ extern crate log;
 extern crate env_logger;
 
 use clap::Parser;
-use ctrlc;
+use colored::*;
+use indicatif::{ProgressBar, ProgressStyle};
 use nexuslab_port_sniffer::constants::{DEFAULT_THREADS, DEFAULT_TIMEOUT, MAX_PORT, MIN_PORT};
-use nexuslab_port_sniffer::models::{IpOrDomain, Ports, LogLevel};
-use std::io::{self, Write};
+use nexuslab_port_sniffer::models::{IpOrDomain, LogLevel, Ports};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender};
@@ -37,7 +37,7 @@ struct Cli {
     ports: Option<Ports>,
 
     /// add a verbose flag
-    #[clap(long="log_level", default_value = "info")]
+    #[clap(long = "log_level", default_value = "info")]
     log_level: LogLevel,
 }
 
@@ -50,7 +50,7 @@ fn main() {
             LogLevel::DEBUG => log::LevelFilter::Debug,
         })
         .init();
-    
+
     let ip_addr = match cli.ip_or_domain.resolve_to_ip() {
         Some(ip_addr) => ip_addr,
         None => {
@@ -61,21 +61,35 @@ fn main() {
     debug!("Resolved to ip: {}", ip_addr);
     let ports_to_scan: Arc<Vec<u32>> = match cli.ports {
         Some(ports) => Arc::new(ports.0),
-        None => Arc::new((MIN_PORT..=MAX_PORT).collect()),
+        None => Arc::new((MIN_PORT..MAX_PORT + 1).collect()),
     };
-
+    let pb: Option<Arc<Mutex<ProgressBar>>> = if cli.log_level != LogLevel::DEBUG {
+        let progress_bar = ProgressBar::new(ports_to_scan.len() as u64).with_tab_width(4);
+        progress_bar.set_style(
+            ProgressStyle::with_template("{bar:50.white/red} {percent}% {msg:.green}").unwrap(),
+        );
+        Some(Arc::new(Mutex::new(progress_bar)))
+    } else {
+        None
+    };
     debug!("Scanning {} with {:?} threads", ip_addr, cli.threads);
-
     let (tx, rx) = channel::<u32>();
     let rx = Arc::new(Mutex::new(rx));
     let rx_clone = rx.clone();
     let terminating = Arc::new(AtomicBool::new(false));
     let terminating_clone = terminating.clone();
-
+    let log_level_ctrlc = cli.log_level.clone(); // This might be unnecessary if cli.log_level implements Copy
     ctrlc::set_handler(move || {
         terminating_clone.store(true, Ordering::Relaxed);
-        print!("\nReceived <Ctrl+C> scan halted, displaying results...");
-        display_results(rx_clone.lock().unwrap().try_iter().collect());
+        if log_level_ctrlc != LogLevel::DEBUG {
+            print!(
+                "{}",
+                "\nReceived <Ctrl+C> scan halted".red().underline().bold()
+            );
+            display_results(rx_clone.lock().unwrap().try_iter().collect());
+        } else {
+            debug!("Received <Ctrl+C> scan halted.");
+        }
         std::process::exit(0);
     })
     .expect("Error setting Ctrl-C handler");
@@ -84,14 +98,15 @@ fn main() {
     let timeouts_count = Arc::new(AtomicUsize::new(0));
     let open_ports_count = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::new();
-
     for i in 0..cli.threads {
         let tx = tx.clone();
         let ports_to_scan = ports_to_scan.clone();
+        let pb = pb.clone();
         let ports_scanned = ports_scanned.clone();
         let timeouts_count = timeouts_count.clone();
         let open_ports_count = open_ports_count.clone();
         let terminating_thread = terminating.clone();
+        let log_level = cli.log_level.clone();
         let handle = thread::spawn(move || {
             scan(
                 tx,
@@ -104,17 +119,27 @@ fn main() {
                 timeouts_count,
                 open_ports_count,
                 terminating_thread,
+                pb,
+                log_level,
             );
         });
         handles.push(handle);
     }
-    drop(tx);
-
     for handle in handles {
         handle.join().unwrap();
     }
-
-    display_results(rx.lock().unwrap().iter().collect());
+    drop(tx);
+    if !terminating.load(Ordering::Relaxed) {
+        if let Some(progress_bar) = &pb {
+            progress_bar.lock().unwrap().finish();
+        }
+        if cli.log_level != LogLevel::DEBUG {
+            print!("{}", " Scanning Complete - Results ".bold().underline());
+            display_results(rx.lock().unwrap().iter().collect());
+        } else {
+            debug!("Scanning Complete");
+        }
+    }
 }
 
 fn display_results(open_ports: Vec<u32>) {
@@ -122,10 +147,15 @@ fn display_results(open_ports: Vec<u32>) {
     let mut open = open_ports;
     open.sort();
     if open.is_empty() {
-        info!("None of the analysed ports were open");
+        println!(
+            "{}",
+            format!("None of the analysed ports were open")
+                .bold()
+                .dimmed()
+        );
     } else {
         for port in open {
-            println!("{} is open", port);
+            println!("{}", format!("  + Port {} is open", port).blue().bold());
         }
     }
 }
@@ -141,6 +171,8 @@ fn scan(
     timeouts_count: Arc<AtomicUsize>,
     open_ports_count: Arc<AtomicUsize>,
     terminating: Arc<AtomicBool>,
+    pb: Option<Arc<Mutex<ProgressBar>>>,
+    log_level: LogLevel,
 ) {
     // This function scans ports at positions
     // start_port_index,
@@ -151,8 +183,9 @@ fn scan(
     let duration = Duration::new(timeout, 0);
     let mut port_index = start_port_index;
     let total_ports = ports_to_scan.len();
+
     loop {
-        if port_index >= total_ports as u32 {
+        if port_index >= ports_to_scan.len() as u32 {
             break;
         }
         let port = ports_to_scan[port_index as usize];
@@ -162,26 +195,30 @@ fn scan(
         if TcpStream::connect_timeout(&socket_add, duration).is_ok() {
             tx.send(port).unwrap();
             open_ports_count.fetch_add(1, Ordering::Relaxed);
+            if log_level == LogLevel::DEBUG {
+                debug!("Port {} is open", port);
+            }
         } else {
             timeouts_count.fetch_add(1, Ordering::Relaxed);
+            if log_level == LogLevel::DEBUG {
+                debug!("Port {} is closed or unreachable", port);
+            }
         }
-
         let scanned = ports_scanned.fetch_add(1, Ordering::Relaxed) + 1;
-        let progress = (scanned as f64 / total_ports as f64) * 100.0;
-
-        if !terminating.load(Ordering::Relaxed) {
-            print!(
-                "\rProgress: {:.2}% (Scanned Ports: {}/{}, Open Ports: {}, Closed Ports: {})",
-                progress,
-                scanned,
-                total_ports,
-                open_ports_count.load(Ordering::Relaxed),
-                timeouts_count.load(Ordering::Relaxed)
-            );
+        if let Some(progress_bar) = &pb {
+            if !terminating.load(Ordering::Relaxed) {
+                let msg = format!(
+                    "\n [*] Scanned Ports: {}/{}\n [*] Open Ports:\t{}\n [*] Closed Ports:  {}",
+                    scanned,
+                    total_ports,
+                    open_ports_count.load(Ordering::Relaxed),
+                    timeouts_count.load(Ordering::Relaxed)
+                );
+                let progress_bar_lock = progress_bar.lock().unwrap();
+                progress_bar_lock.set_message(msg);
+                progress_bar_lock.inc(1);
+            }
         }
-
-        io::stdout().flush().unwrap();
-
         port_index += total_threads;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 use clap::Parser;
+use ctrlc;
 use nexuslab_port_sniffer::constants::{DEFAULT_THREADS, DEFAULT_TIMEOUT, MAX_PORT, MIN_PORT};
 use nexuslab_port_sniffer::models::{IpOrDomain, Ports};
 use std::io::{self, Write};
 use std::net::{IpAddr, TcpStream, ToSocketAddrs};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -49,20 +52,49 @@ fn main() {
     println!("Scanning {} with {:?} threads", ip_addr, cli.threads);
 
     let (tx, rx) = channel::<u32>();
+    let rx = Arc::new(Mutex::new(rx));
+    let rx_clone = rx.clone();
+
+    ctrlc::set_handler(move || {
+        print!("\nReceived <Ctrl+C> scan halted, displaying results...");
+        display_results(rx_clone.lock().unwrap().try_iter().collect());
+        std::process::exit(0);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let ports_scanned = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::new();
 
     for i in 0..cli.threads {
         let tx = tx.clone();
         let ports_to_scan = ports_to_scan.clone();
-        thread::spawn(move || {
-            scan(tx, ports_to_scan, i, ip_addr, cli.threads, cli.timeout);
+        let ports_scanned = ports_scanned.clone();
+        let handle = thread::spawn(move || {
+            scan(
+                tx,
+                ports_to_scan,
+                i,
+                ip_addr,
+                cli.threads,
+                cli.timeout,
+                ports_scanned,
+            );
         });
+        handles.push(handle);
     }
     drop(tx);
-    let mut open: Vec<u32> = rx.iter().collect();
 
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    display_results(rx.lock().unwrap().iter().collect());
+}
+
+fn display_results(open_ports: Vec<u32>) {
     println!();
+    let mut open = open_ports;
     open.sort();
-
     if open.is_empty() {
         println!("None of the analysed ports were open");
     } else {
@@ -79,6 +111,7 @@ fn scan(
     addr: IpAddr,
     threads: u32,
     timeout: u64,
+    ports_scanned: Arc<AtomicUsize>,
 ) {
     // This function scans ports at positions
     // start_port_index,
@@ -88,8 +121,9 @@ fn scan(
 
     let duration = Duration::new(timeout, 0);
     let mut port_index = start_port_index;
+    let total_ports = ports_to_scan.len();
     loop {
-        if port_index >= ports_to_scan.len() as u32 {
+        if port_index >= total_ports as u32 {
             break;
         }
         let port = ports_to_scan[port_index as usize];
@@ -100,6 +134,17 @@ fn scan(
             io::stdout().flush().unwrap();
             tx.send(port).unwrap();
         }
+
+        let scanned = ports_scanned.fetch_add(1, Ordering::Relaxed) + 1;
+        let progress = (scanned as f64 / total_ports as f64) * 100.0;
+
+        print!(
+            "\rProgress: {:.2}% (Scanned {} out of {})",
+            progress, scanned, total_ports
+        );
+
+        io::stdout().flush().unwrap();
+
         port_index += threads;
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -84,7 +84,7 @@ impl FromStr for Ports {
                 return Err(String::from("Invalid range: start must be less than end"));
             }
 
-            Ok(Ports((start..end).collect()))
+            Ok(Ports((start..=end).collect()))
         } else {
             let list: Result<Vec<u32>, _> = s
                 .split_whitespace()
@@ -94,7 +94,7 @@ impl FromStr for Ports {
             match list {
                 Ok(ports) => {
                     for port in ports.clone() {
-                        if !(MIN_PORT..MAX_PORT).contains(&port) {
+                        if !(MIN_PORT..=MAX_PORT).contains(&port) {
                             return Err(format!(
                         "Invalid port number specified. Port numbers should be in the range: {}-{}",
                         MIN_PORT, MAX_PORT));

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,7 @@ use clap::ValueEnum;
 use dns_lookup::lookup_host;
 
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
 pub enum LogLevel {
     INFO,
     DEBUG,
@@ -103,7 +103,7 @@ impl FromStr for Ports {
             match list {
                 Ok(ports) => {
                     for port in ports.clone() {
-                        if !(MIN_PORT..=MAX_PORT).contains(&port) {
+                        if !(MIN_PORT..MAX_PORT).contains(&port) {
                             return Err(format!(
                         "Invalid port number specified. Port numbers should be in the range: {}-{}",
                         MIN_PORT, MAX_PORT));


### PR DESCRIPTION
![image](https://github.com/nexus-lab-org/port-sniffer/assets/16103757/41712726-a94f-4f1a-a3d6-aef1d55bf957)

This PR closes issue #18

**Here are the changes:**

- **Dependencies Update**: Added new dependencies to Cargo.toml:
  - _indicatif_: Provides progress bar capabilities.
  - _ctrlc_: For handling Ctrl+C (SIGINT) keyboard interrupt.
  - _colored_: Allows for colored console output.

- **Progress Bar**: Implemented a progress bar for the scanning process using indicatif, providing users with a visual update on the scanning progress. The progress bar is styled with a white/red template and displays percentage completion.
- **CTRL+C (SIGINT) Handling**: Added handling for Ctrl+C interrupts using ctrlc. Now, if the user interrupts the scan with Ctrl+C, the scan stops, and results up to that point are displayed. For verbose (DEBUG) mode, a debug message is logged upon interruption.
- **Enhanced Logging and Output**: Refactored the scan results display. Ports found open now have a blue color in the output. Added more debug log messages during the scanning process. For each port scanned, a log indicating whether the port is open or closed/unreachable is recorded.
- **Thread Management**: Improved multi-threading for port scanning. Each thread's execution is now handled with more care, allowing for better synchronization between threads.
  - _Thread Completion_: Ensured that the main thread waits for all spawned threads to complete before proceeding. This guarantees that all threads finish and no thread is left executing independently.
  - _Shared Counters_: Introduced atomic counters to keep track of ports scanned, open ports, and timeouts. This allows threads to update shared statistics concurrently without risking data races.
  - _Graceful Termination_: Added a shared atomic boolean flag to signal all threads in the event of an external termination request, ensuring all threads can be halted gracefully.
  - _Integrated Feedback_: Threads now update the progress bar in real-time as they scan ports, providing immediate feedback to the user.
- **Statistics**: The number of ports scanned, open ports, and closed ports are now displayed as part of the progress bar's message.
- **Code changes**: Various small changes, such as:
  - Moved the results display functionality to a separate display_results function.
  - Updated comments.
  - Minor formatting changes.